### PR TITLE
Include H5VLpassthru_ext_private.h instead of H5VLpassthru_ext.h from

### DIFF
--- a/H5VLpassthru_ext.c
+++ b/H5VLpassthru_ext.c
@@ -40,7 +40,8 @@
 #include "hdf5.h"
 
 /* This connector's private header */
-#include "H5VLpassthru_ext.h"
+#include "H5VLpassthru_ext_private.h
+
 
 /**********/
 /* Macros */


### PR DESCRIPTION
H5VLpassthru_ext.c to fix compile errors.